### PR TITLE
fixed 2 undefined variable bugs of server

### DIFF
--- a/server_njs/aemu_postoffice.js
+++ b/server_njs/aemu_postoffice.js
@@ -518,7 +518,7 @@ function create_session(ctx){
 
 			let listen_session = find_target_session("ptp_listen", ctx.src_addr_str, ctx.dst_addr_str, 0, ctx.dport);
 			if (listen_session == undefined){
-				log(`not creating ${ctx.session_name} for ${get_sock_addr_str(ctx.socket)}, ${listen_session_name} not found`);
+				log(`not creating ${ctx.session_name} for ${get_sock_addr_str(ctx.socket)}, target listen session not found`);
 				ctx.socket.destroy();
 				break;
 			}
@@ -547,7 +547,7 @@ function create_session(ctx){
 
 			let connect_session = find_target_session("ptp_connect", ctx.src_addr_str, ctx.dst_addr_str, ctx.sport, ctx.dport);
 			if (connect_session == undefined){
-				log(`${connect_session_name} not found, closing ${ctx.session_name} of ${get_sock_addr_str(ctx.socket)}`);
+				log(`connect session not found, closing ${ctx.session_name} of ${get_sock_addr_str(ctx.socket)}`);
 				ctx.socket.destroy();
 				break;
 			}


### PR DESCRIPTION
Found connection bug caused by undefined variable in Final Fantasy Dissidia 012(NPHH00293 and NPJH50377). When using the communication mode and start a battle, client will cause the server fail down. By fix these undefined variable bugs, client can normally start a battle. However, client still meeting strict sync fail down with unknown reason.

the output of server of these fail down bug is shown below:
```bash
# node aemu_postoffice.js

Tue Mar 10 2026 23:52:22 GMT+0800 (China Standard Time): runtime config:

{

    "connection_strict_mode": false,

    "forwarding_strict_mode": false,

    "max_per_second_data_rate_byte": 0,

    "max_tx_op_rate": 0

}

Tue Mar 10 2026 23:52:22 GMT+0800 (China Standard Time): begin listening on port 27313

Tue Mar 10 2026 23:52:22 GMT+0800 (China Standard Time): begin listening on port 27314 for server status

Tue Mar 10 2026 23:56:24 GMT+0800 (China Standard Time): created session PDP 18:d3:e3:22:39:d3 100 for ::ffff:183.137.158.16:14906

--- usage statistics Tue Mar 10 2026 23:56:52 GMT+0800 (China Standard Time) of the last 0.5 minutes ---

::ffff:183.137.158.16:

  pdp connects 1 avg 0.03333333333333333/s

  pdp tx ops 0 avg 0/s

  pdp tx 0 bytes avg 0 bytes/s

  pdp rx ops 0 avg 0/s

  pdp rx 0 bytes avg 0 bytes/s

  ptp connects 0 avg 0/s

  ptp listen connects 0 avg 0/s

  ptp tx ops 0 avg 0/s

  ptp tx 0 bytes avg 0 bytes/s

  ptp rx ops 0 avg 0/s

  ptp rx 0 bytes avg 0 bytes/s

  total connects: 1 avg 0.03333333333333333/s

  total tx ops: 0 avg 0/s

  total rx ops: 0 avg 0/s

  total ops: 0 avg 0/s

  total tx: 0 avg 0 bytes/s

  total rx: 0 avg 0 bytes/s

  total data: 0 avg 0 bytes/s

Tue Mar 10 2026 23:57:05 GMT+0800 (China Standard Time): created session PDP 74:15:db:3b:f1:80 100 for ::ffff:125.119.84.126:53367

Tue Mar 10 2026 23:57:18 GMT+0800 (China Standard Time): PDP 74:15:db:3b:f1:80 100 ::ffff:125.119.84.126:53367 closed by client

Tue Mar 10 2026 23:57:18 GMT+0800 (China Standard Time): closing PDP 74:15:db:3b:f1:80 100

Tue Mar 10 2026 23:57:18 GMT+0800 (China Standard Time): PDP 18:d3:e3:22:39:d3 100 ::ffff:183.137.158.16:14906 closed by client

Tue Mar 10 2026 23:57:18 GMT+0800 (China Standard Time): closing PDP 18:d3:e3:22:39:d3 100

Tue Mar 10 2026 23:57:19 GMT+0800 (China Standard Time): created session PDP 18:d3:e3:22:39:d3 104 for ::ffff:183.137.158.16:15021

/root/workspace/aemu_postoffice/server_njs/aemu_postoffice.js:521

                                log(`not creating ${ctx.session_name} for ${get_sock_addr_str(ctx.socket)}, ${listen_session_name} not found`);

                                                                                                              ^



ReferenceError: listen_session_name is not defined

    at create_session (/root/workspace/aemu_postoffice/server_njs/aemu_postoffice.js:521:83)

    at Socket.<anonymous> (/root/workspace/aemu_postoffice/server_njs/aemu_postoffice.js:645:6)

    at Socket.emit (node:events:517:28)

    at addChunk (node:internal/streams/readable:368:12)

    at readableAddChunk (node:internal/streams/readable:341:9)

    at Readable.push (node:internal/streams/readable:278:10)

    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)



Node.js v18.19.1
```