### PR TITLE
make client ptp recv and size peek more stream like

### DIFF
--- a/client/mutex_impl.h
+++ b/client/mutex_impl.h
@@ -9,6 +9,10 @@ void init_sock_alloc_mutex();
 void lock_sock_alloc_mutex();
 void unlock_sock_alloc_mutex();
 
+void init_drain_mutex();
+void lock_drain_mutex();
+void unlock_drain_mutex();
+
 #ifdef __cplusplus
 }
 #endif

--- a/client/mutex_impl_cpp.cpp
+++ b/client/mutex_impl_cpp.cpp
@@ -12,4 +12,14 @@ void unlock_sock_alloc_mutex(){
 	sock_alloc_mutex.unlock();
 }
 
+static std::mutex drain_mutex;
+void init_drain_mutex(){
+}
+void lock_drain_mutex(){
+	drain_mutex.lock();
+}
+void unlock_drain_mutex(){
+	drain_mutex.unlock();
+}
+
 }

--- a/client/mutex_impl_psp.c
+++ b/client/mutex_impl_psp.c
@@ -2,11 +2,24 @@
 
 static SceLwMutexWorkarea sock_alloc_mutex;
 void init_sock_alloc_mutex(){
-	sceKernelCreateLwMutex(&sock_alloc_mutex, "aemu_postoffice_client", 0, 0, NULL);
+	sceKernelCreateLwMutex(&sock_alloc_mutex, "aemu_postoffice sock_alloc_mutex", 0, 0, NULL);
 }
 void lock_sock_alloc_mutex(){
 	sceKernelLockLwMutex(&sock_alloc_mutex, 1, 0);
 }
 void unlock_sock_alloc_mutex(){
 	sceKernelUnlockLwMutex(&sock_alloc_mutex, 1);
+}
+
+// generally we do not expect applications to trigger buffer -> ring buffer on the same socket on different threads
+// however pspemu_inet_multithread used along with a few games will trigger that by yielding on nonblock inet functions, so guard it
+static SceLwMutexWorkarea drain_mutex;
+void init_drain_mutex(){
+	sceKernelCreateLwMutex(&drain_mutex, "aemu_postoffice drain_mutex", 0, 0, NULL);
+}
+void lock_drain_mutex(){
+	sceKernelLockLwMutex(&drain_mutex, 1, 0);
+}
+void unlock_drain_mutex(){
+	sceKernelUnlockLwMutex(&drain_mutex, 1);
 }

--- a/client/postoffice.c
+++ b/client/postoffice.c
@@ -431,6 +431,19 @@ int pdp_send_buf_not_full(void *pdp_handle){
 	return native_send_buf_not_full(session->sock);
 }
 
+int pdp_is_dead(void *pdp_handle){
+	if (pdp_handle == NULL){
+		return 1;
+	}
+
+	struct pdp_session *session = (struct pdp_session *)pdp_handle;
+	if (session->dead || session->abort){
+		return 1;
+	}
+
+	return 0;
+}
+
 static void *ptp_listen(void *addr, int addrlen, const char *ptp_mac, int ptp_port, int *state){
 	struct ptp_listen_session* session = NULL;
 	lock_sock_alloc_mutex();
@@ -961,4 +974,30 @@ int ptp_listen_has_request(void *ptp_listen_handle){
 		return 0;
 	}
 	return 1;
+}
+
+int ptp_is_dead(void *ptp_handle){
+	if (ptp_handle == NULL){
+		return 1;
+	}
+
+	struct ptp_session *session = (struct ptp_session *)ptp_handle;
+	if (session->dead || session->abort){
+		return 1;
+	}
+
+	return 0;
+}
+
+int ptp_listen_is_dead(void *ptp_listen_handle){
+	if (ptp_listen_handle == NULL){
+		return 1;
+	}
+
+	struct ptp_listen_session *session = (struct ptp_listen_session *)ptp_listen_handle;
+	if (session->dead){
+		return 1;
+	}
+
+	return 0;
 }

--- a/client/postoffice.c
+++ b/client/postoffice.c
@@ -421,6 +421,16 @@ int pdp_buffered_data_size(void *pdp_handle){
 	return session->buffered_data;
 }
 
+int pdp_send_buf_not_full(void *pdp_handle){
+	struct pdp_session *session = pdp_handle;
+
+	if (session->dead || session->abort){
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+
+	return native_send_buf_not_full(session->sock);
+}
+
 static void *ptp_listen(void *addr, int addrlen, const char *ptp_mac, int ptp_port, int *state){
 	struct ptp_listen_session* session = NULL;
 	lock_sock_alloc_mutex();
@@ -908,4 +918,47 @@ int ptp_peek_next_size(void *ptp_handle){
 	// AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK
 
 	return session->recv_ring_buf_used;
+}
+
+int ptp_send_buf_not_full(void *ptp_handle){
+	struct ptp_session *session = ptp_handle;
+
+	if (session->dead || session->abort){
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+
+	return native_send_buf_not_full(session->sock);
+}
+
+int ptp_listen_has_request(void *ptp_listen_handle){
+	if (ptp_listen_handle == NULL){
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+
+	struct ptp_listen_session *session = (struct ptp_listen_session *)ptp_listen_handle;
+	if (session->dead){
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+
+	struct aemu_postoffice_ptp_connect connect_packet;
+	int peek_result = native_peek(session->sock, (char *)&connect_packet, sizeof(connect_packet));
+	if (peek_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
+		return 0;
+	}
+	if (peek_result == 0){
+		LOG("%s: the other side closed the listen socket\n", __func__);
+		session->dead = true;
+		native_close_tcp_sock(session->sock);
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+	if (peek_result <= 0){
+		LOG("%s: socket error\n", __func__);
+		session->dead = true;
+		native_close_tcp_sock(session->sock);
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+	if (peek_result != sizeof(connect_packet)){
+		return 0;
+	}
+	return 1;
 }

--- a/client/postoffice.c
+++ b/client/postoffice.c
@@ -29,6 +29,7 @@ int aemu_post_office_init(){
 		}
 
 		init_sock_alloc_mutex();
+		init_drain_mutex();
 	}else{
 		// re-run, close all opened sessions
 		for (int i = 0;i < NUM_PDP_SESSIONS;i++){
@@ -302,6 +303,15 @@ static int pdp_drain_blocks_to_ring_buf(struct pdp_session *session){
 	}
 }
 
+static int pdp_drain_blocks_to_ring_buf_locked(struct pdp_session *session){
+	session->recving = true;
+	lock_drain_mutex();
+	int result = pdp_drain_blocks_to_ring_buf(session);
+	unlock_drain_mutex();
+	session->recving = false;
+	return result;
+}
+
 int pdp_recv(void *pdp_handle, char *pdp_mac, int *pdp_port, char *buf, int *len, bool non_block){
 	if (pdp_handle == NULL){
 		return -1;
@@ -315,7 +325,7 @@ int pdp_recv(void *pdp_handle, char *pdp_mac, int *pdp_port, char *buf, int *len
 		if (session->abort){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
-		int drain_result = pdp_drain_blocks_to_ring_buf(session);
+		int drain_result = pdp_drain_blocks_to_ring_buf_locked(session);
 		if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
@@ -389,7 +399,7 @@ int pdp_peek_next_size(void *pdp_handle){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	int drain_result = pdp_drain_blocks_to_ring_buf(session);
+	int drain_result = pdp_drain_blocks_to_ring_buf_locked(session);
 	if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
@@ -413,7 +423,7 @@ int pdp_buffered_data_size(void *pdp_handle){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	int drain_result = pdp_drain_blocks_to_ring_buf(session);
+	int drain_result = pdp_drain_blocks_to_ring_buf_locked(session);
 	if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
@@ -822,6 +832,15 @@ static int ptp_drain_blocks_to_ring_buf(struct ptp_session *session){
 	}
 }
 
+static int ptp_drain_blocks_to_ring_buf_locked(struct ptp_session *session){
+	session->recving = true;
+	lock_drain_mutex();
+	int result = ptp_drain_blocks_to_ring_buf(session);
+	unlock_drain_mutex();
+	session->recving = false;
+	return result;
+}
+
 int ptp_recv(void *ptp_handle, char *buf, int *len, bool non_block){
 	if (ptp_handle == NULL){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
@@ -836,7 +855,7 @@ int ptp_recv(void *ptp_handle, char *buf, int *len, bool non_block){
 		if (session->abort){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
-		int drain_result = ptp_drain_blocks_to_ring_buf(session);
+		int drain_result = ptp_drain_blocks_to_ring_buf_locked(session);
 		if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
@@ -924,7 +943,7 @@ int ptp_peek_next_size(void *ptp_handle){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	int drain_result = ptp_drain_blocks_to_ring_buf(session);
+	int drain_result = ptp_drain_blocks_to_ring_buf_locked(session);
 	if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}

--- a/client/postoffice.c
+++ b/client/postoffice.c
@@ -431,16 +431,6 @@ int pdp_buffered_data_size(void *pdp_handle){
 	return session->buffered_data;
 }
 
-int pdp_send_buf_not_full(void *pdp_handle){
-	struct pdp_session *session = pdp_handle;
-
-	if (session->dead || session->abort){
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	return native_send_buf_not_full(session->sock);
-}
-
 int pdp_is_dead(void *pdp_handle){
 	if (pdp_handle == NULL){
 		return 1;
@@ -451,7 +441,24 @@ int pdp_is_dead(void *pdp_handle){
 		return 1;
 	}
 
+	if (native_hung_up(session->sock)){
+		LOG("%s: the other side closed the listen socket\n", __func__);
+		session->dead = true;
+		native_close_tcp_sock(session->sock);
+		return 1;
+	}
+
 	return 0;
+}
+
+int pdp_send_buf_not_full(void *pdp_handle){
+	if (pdp_is_dead(pdp_handle)){
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+
+	struct pdp_session *session = pdp_handle;
+
+	return native_send_buf_not_full(session->sock);
 }
 
 static void *ptp_listen(void *addr, int addrlen, const char *ptp_mac, int ptp_port, int *state){
@@ -952,14 +959,54 @@ int ptp_peek_next_size(void *ptp_handle){
 	return session->recv_ring_buf_used;
 }
 
-int ptp_send_buf_not_full(void *ptp_handle){
-	struct ptp_session *session = ptp_handle;
+int ptp_is_dead(void *ptp_handle){
+	if (ptp_handle == NULL){
+		return 1;
+	}
 
+	struct ptp_session *session = (struct ptp_session *)ptp_handle;
 	if (session->dead || session->abort){
+		return 1;
+	}
+
+	if (native_hung_up(session->sock)){
+		LOG("%s: the other side closed the listen socket\n", __func__);
+		session->dead = true;
+		native_close_tcp_sock(session->sock);
+		return 1;
+	}
+
+	return 0;
+}
+
+int ptp_send_buf_not_full(void *ptp_handle){
+	if (ptp_is_dead(ptp_handle)){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
+	struct ptp_session *session = ptp_handle;
+
 	return native_send_buf_not_full(session->sock);
+}
+
+int ptp_listen_is_dead(void *ptp_listen_handle){
+	if (ptp_listen_handle == NULL){
+		return 1;
+	}
+
+	struct ptp_listen_session *session = (struct ptp_listen_session *)ptp_listen_handle;
+	if (session->dead){
+		return 1;
+	}
+
+	if (native_hung_up(session->sock)){
+		LOG("%s: the other side closed the listen socket\n", __func__);
+		session->dead = true;
+		native_close_tcp_sock(session->sock);
+		return 1;
+	}
+
+	return 0;
 }
 
 int ptp_listen_has_request(void *ptp_listen_handle){
@@ -967,10 +1014,11 @@ int ptp_listen_has_request(void *ptp_listen_handle){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	struct ptp_listen_session *session = (struct ptp_listen_session *)ptp_listen_handle;
-	if (session->dead){
+	if (ptp_listen_is_dead(ptp_listen_handle)){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
+
+	struct ptp_listen_session *session = (struct ptp_listen_session *)ptp_listen_handle;
 
 	struct aemu_postoffice_ptp_connect connect_packet;
 	int peek_result = native_peek(session->sock, (char *)&connect_packet, sizeof(connect_packet));
@@ -993,30 +1041,4 @@ int ptp_listen_has_request(void *ptp_listen_handle){
 		return 0;
 	}
 	return 1;
-}
-
-int ptp_is_dead(void *ptp_handle){
-	if (ptp_handle == NULL){
-		return 1;
-	}
-
-	struct ptp_session *session = (struct ptp_session *)ptp_handle;
-	if (session->dead || session->abort){
-		return 1;
-	}
-
-	return 0;
-}
-
-int ptp_listen_is_dead(void *ptp_listen_handle){
-	if (ptp_listen_handle == NULL){
-		return 1;
-	}
-
-	struct ptp_listen_session *session = (struct ptp_listen_session *)ptp_listen_handle;
-	if (session->dead){
-		return 1;
-	}
-
-	return 0;
 }

--- a/client/postoffice.c
+++ b/client/postoffice.c
@@ -106,6 +106,11 @@ static void *pdp_create(void *addr, int addrlen, const char *pdp_mac, int pdp_po
 	session->abort = false;
 	session->recving = false;
 	session->sending = false;
+	session->recv_ring_buf_start = 0;
+	session->recv_ring_buf_used = 0;
+	session->buffered_data = 0;
+	session->bytes_till_next_header = 0;
+	session->last_block_size = 0;
 
 	*state = AEMU_POSTOFFICE_CLIENT_OK;
 	return session;
@@ -134,7 +139,7 @@ int pdp_send(void *pdp_handle, const char *pdp_mac, int pdp_port, const char *bu
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	if (len > sizeof(session->recv_buf)){
+	if (len > AEMU_POSTOFFICE_PDP_BLOCK_MAX){
 		LOG("%s: failed sending data, data too big, %d\n", __func__, len);
 		return AEMU_POSTOFFICE_CLIENT_OUT_OF_MEMORY;
 	}
@@ -184,6 +189,119 @@ int pdp_send(void *pdp_handle, const char *pdp_mac, int pdp_port, const char *bu
 	return AEMU_POSTOFFICE_CLIENT_OK;
 }
 
+static int peek_ring_buf(uint8_t *dst, int dst_size, const uint8_t *ring_buf, int ring_buf_size, int ring_buf_begin, int ring_buf_used){
+	int to_peek = dst_size > ring_buf_used ? ring_buf_used : dst_size;
+	for (int i = 0;i < to_peek;i++){
+		int ring_buf_offset = (ring_buf_begin + i) % ring_buf_size;
+		dst[i] = ring_buf[ring_buf_offset];
+	}
+	return to_peek;
+}
+
+static int consume_ring_buf(uint8_t *dst, int dst_size, const uint8_t *ring_buf, int ring_buf_size, int *ring_buf_begin, int *ring_buf_used){
+	int peeked = peek_ring_buf(dst, dst_size, ring_buf, ring_buf_size, *ring_buf_begin, *ring_buf_used);
+	*ring_buf_begin = (*ring_buf_begin + peeked) % ring_buf_size;
+	*ring_buf_used = *ring_buf_used - peeked;
+	return peeked;
+}
+
+static int pdp_drain_blocks_to_ring_buf(struct pdp_session *session){
+	while (true){
+		int ring_buf_free = sizeof(session->recv_ring_buf) - session->recv_ring_buf_used;
+		if (session->bytes_till_next_header == 0){
+			if (session->last_block_size != 0){
+				session->buffered_data = session->buffered_data + session->last_block_size;
+				session->last_block_size = 0;
+			}
+			if (ring_buf_free < sizeof(aemu_postoffice_pdp)){
+				return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+			}
+
+			aemu_postoffice_pdp header;
+			int peek_len = native_peek(session->sock, (char *)&header, sizeof(header));
+			if (peek_len == 0){
+				LOG("%s: remote closed the socket\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+			if (peek_len == -1){
+				LOG("%s: failed peeking header\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+			if (peek_len != sizeof(header)){
+				return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+			}
+
+			int recv_status = native_recv(session->sock, (char *)&header, sizeof(header));
+			if (recv_status == 0){
+				LOG("%s: remote closed the socket\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+			if (recv_status == -1){
+				LOG("%s: failed receiving header\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+			if (header.size > AEMU_POSTOFFICE_PDP_BLOCK_MAX){
+				LOG("%s: remote sent unexpected amount of data\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+
+			session->bytes_till_next_header = header.size;
+			session->last_block_size = header.size;
+			uint8_t *header_bytes = (uint8_t *)&header;
+			int ring_buf_end = (session->recv_ring_buf_start + session->recv_ring_buf_used) % sizeof(session->recv_ring_buf);
+			for (int i = 0;i < sizeof(header);i++){
+				int ring_buf_offset = (ring_buf_end + i) % sizeof(session->recv_ring_buf);
+				session->recv_ring_buf[ring_buf_offset] = header_bytes[i];
+			}
+			session->recv_ring_buf_used = session->recv_ring_buf_used + sizeof(header);
+			continue;
+		}
+
+		int ring_buf_end = (session->recv_ring_buf_start + session->recv_ring_buf_used) % sizeof(session->recv_ring_buf);
+		int linear_size_from_end = sizeof(session->recv_ring_buf) - ring_buf_end;
+		int to_consume = ring_buf_free;
+		if (to_consume > linear_size_from_end){
+			to_consume = linear_size_from_end;
+		}
+		if (to_consume > session->bytes_till_next_header){
+			to_consume = session->bytes_till_next_header;
+		}
+
+		if (to_consume == 0){
+			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		}
+
+		int recv_status = native_recv(session->sock, &session->recv_ring_buf[ring_buf_end], to_consume);
+		if (recv_status == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
+			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		}
+		if (recv_status == 0){
+			LOG("%s: remote closed the socket\n", __func__);
+			native_close_tcp_sock(session->sock);
+			session->dead = true;
+			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+		}
+		if (recv_status == -1){
+			LOG("%s: failed receiving data\n", __func__);
+			native_close_tcp_sock(session->sock);
+			session->dead = true;
+			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+		}
+		session->recv_ring_buf_used = session->recv_ring_buf_used + recv_status;
+		session->bytes_till_next_header = session->bytes_till_next_header - recv_status;
+	}
+}
+
 int pdp_recv(void *pdp_handle, char *pdp_mac, int *pdp_port, char *buf, int *len, bool non_block){
 	if (pdp_handle == NULL){
 		return -1;
@@ -193,100 +311,55 @@ int pdp_recv(void *pdp_handle, char *pdp_mac, int *pdp_port, char *buf, int *len
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	if (*len > sizeof(session->recv_buf)){
-		return AEMU_POSTOFFICE_CLIENT_OUT_OF_MEMORY;
-	}
-
-	struct aemu_postoffice_pdp pdp_header;
-
-	if (non_block){
-		// take a peek at the message
-		int peek_len = native_peek(session->sock, (char *)&pdp_header, sizeof(pdp_header));
-		if (peek_len == -1){
-			native_close_tcp_sock(session->sock);
-			session->dead = true;
+	while (true){
+		if (session->abort){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
-		if (peek_len != sizeof(pdp_header)){
-			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
-		}
-
-		int full_message_len = pdp_header.size + sizeof(pdp_header);
-		int min_len = full_message_len > 2048 ? 2048 : full_message_len;
-
-		peek_len = native_peek(session->sock, session->recv_buf, min_len);
-		if (peek_len == -1){
-			native_close_tcp_sock(session->sock);
-			session->dead = true;
+		int drain_result = pdp_drain_blocks_to_ring_buf(session);
+		if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
-		if (peek_len != min_len){
-			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		// AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK
+
+		aemu_postoffice_pdp header;
+		int peeked = peek_ring_buf((uint8_t *)&header, sizeof(header), (uint8_t *)session->recv_ring_buf, sizeof(session->recv_ring_buf), session->recv_ring_buf_start, session->recv_ring_buf_used);
+		if (peeked != sizeof(header)){
+			if (non_block){
+				return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+			}else{
+				// yield so that on the PSP new data can get into the recv buffer
+				delay(0);
+				continue;
+			}
 		}
+
+		int total_size = sizeof(header) + header.size;
+		if (total_size > session->recv_ring_buf_used){
+			if (non_block){
+				return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+			}else{
+				// yield so that on the PSP new data can get into the recv buffer
+				delay(0);
+				continue;
+			}
+		}
+
+		break;
 	}
 
-	session->recving = true;
-	int recv_status = native_recv_till_done(session->sock, (char *)&pdp_header, sizeof(pdp_header), non_block, &session->abort);
-	session->recving = false;
-	if (recv_status == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
-		return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
-	}
-	if (recv_status == NATIVE_SOCK_ABORTED){
-		// getting aborted
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (recv_status == 0){
-		LOG("%s: remote closed the socket\n", __func__);
-		native_close_tcp_sock(session->sock);
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (recv_status == -1){
-		LOG("%s: failed receiving data\n", __func__);
-		native_close_tcp_sock(session->sock);
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	// We have a header
-	if (pdp_header.size > sizeof(session->recv_buf)){
-		// The other side is sending packets that are too big
-		LOG("%s: failed receiving data, data too big %d\n", __func__, pdp_header.size);
-		native_close_tcp_sock(session->sock);
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (pdp_mac != NULL)
-		memcpy(pdp_mac, pdp_header.addr, 6);
-	if (pdp_port != NULL)
-		*pdp_port = pdp_header.port;
-
-	session->recving = true;
-	recv_status = native_recv_till_done(session->sock, session->recv_buf, pdp_header.size, false, &session->abort);
-	session->recving = false;
-	if (recv_status == NATIVE_SOCK_ABORTED){
-		// getting aborted
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (recv_status == 0){
-		LOG("%s: remote closed the socket\n", __func__);
-		native_close_tcp_sock(session->sock);
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (recv_status == -1){
-		LOG("%s: failed receiving data\n", __func__);
-		native_close_tcp_sock(session->sock);
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	// We have data
-	memcpy(buf, session->recv_buf, pdp_header.size > *len ? *len : pdp_header.size);
-	if (pdp_header.size > *len){
+	aemu_postoffice_pdp header;
+	peek_ring_buf((uint8_t *)&header, sizeof(header), (uint8_t *)session->recv_ring_buf, sizeof(session->recv_ring_buf), session->recv_ring_buf_start, session->recv_ring_buf_used);
+	*pdp_port = header.port;
+	memcpy(pdp_mac, header.addr, 6);
+	if (header.size > *len){
+		*len = header.size;
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DATA_TRUNC;
 	}
-	*len = pdp_header.size;
+	consume_ring_buf((uint8_t *)&header, sizeof(header), (uint8_t *)session->recv_ring_buf, sizeof(session->recv_ring_buf), &session->recv_ring_buf_start, &session->recv_ring_buf_used);
+	consume_ring_buf((uint8_t *)buf, header.size, (uint8_t *)session->recv_ring_buf, sizeof(session->recv_ring_buf), &session->recv_ring_buf_start, &session->recv_ring_buf_used);
+	session->buffered_data = session->buffered_data - header.size;
+	*len = header.size;
+
 	return AEMU_POSTOFFICE_CLIENT_OK;
 }
 
@@ -316,28 +389,36 @@ int pdp_peek_next_size(void *pdp_handle){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	aemu_postoffice_pdp header = {0};
-	session->recving = true;
-	int peek_result = native_peek(session->sock, (char *)&header, sizeof(header));
-	session->recving = false;
-	if (peek_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
-		return 0;
-	}
-	if (session->abort){
+	int drain_result = pdp_drain_blocks_to_ring_buf(session);
+	if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	if (peek_result <= 0){
-		session->dead = true;
-		native_close_tcp_sock(session->sock);
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (peek_result != sizeof(header)){
+	if (session->recv_ring_buf_used < sizeof(aemu_postoffice_pdp)){
 		return 0;
 	}
 
-	return header.size;
+	aemu_postoffice_pdp header;
+	peek_ring_buf((uint8_t *)&header, sizeof(header), session->recv_ring_buf, sizeof(session->recv_ring_buf), session->recv_ring_buf_start, session->recv_ring_buf_used);
+	if (session->buffered_data >= header.size){
+		return header.size;
+	}
+	return 0;
+}
+
+int pdp_buffered_data_size(void *pdp_handle){
+	struct pdp_session *session = pdp_handle;
+
+	if (session->dead || session->abort){
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+
+	int drain_result = pdp_drain_blocks_to_ring_buf(session);
+	if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
+		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+	}
+
+	return session->buffered_data;
 }
 
 static void *ptp_listen(void *addr, int addrlen, const char *ptp_mac, int ptp_port, int *state){
@@ -636,17 +717,6 @@ int ptp_send(void *ptp_handle, const char *buf, int len, bool non_block){
 	return AEMU_POSTOFFICE_CLIENT_OK;
 }
 
-static int consume_ring_buf(uint8_t *dst, int dst_size, const uint8_t *ring_buf, int ring_buf_size, int *ring_buf_begin, int *ring_buf_used){
-	int to_consume = dst_size > *ring_buf_used ? *ring_buf_used : dst_size;
-	for (int i = 0;i < to_consume;i++){
-		int ring_buf_offset = (*ring_buf_begin + i) % ring_buf_size;
-		dst[i] = ring_buf[ring_buf_offset];
-	}
-	*ring_buf_begin = (*ring_buf_begin + to_consume) % ring_buf_size;
-	*ring_buf_used = *ring_buf_used - to_consume;
-	return to_consume;
-}
-
 static int ptp_drain_blocks_to_ring_buf(struct ptp_session *session){
 	while(true){
 		if (session->bytes_till_next_header == 0){
@@ -679,6 +749,13 @@ static int ptp_drain_blocks_to_ring_buf(struct ptp_session *session){
 			}
 			if (recv_status == -1){
 				LOG("%s: failed reading header\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+
+			if (header.size > AEMU_POSTOFFICE_PTP_BLOCK_MAX){
+				LOG("%s: remote sent unexpected amount of data\n", __func__);
 				native_close_tcp_sock(session->sock);
 				session->dead = true;
 				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;

--- a/client/postoffice.c
+++ b/client/postoffice.c
@@ -494,7 +494,9 @@ void *ptp_accept(void *ptp_listen_handle, char *ptp_mac, int *ptp_port, bool non
 	new_session->abort = false;
 	new_session->sending = false;
 	new_session->recving = false;
-	new_session->outstanding_data_size = 0;
+	new_session->recv_ring_buf_start = 0;
+	new_session->recv_ring_buf_used = 0;
+	new_session->bytes_till_next_header = 0;
 	*state = AEMU_POSTOFFICE_CLIENT_OK;
 	*ptp_port = connect_packet.port;
 	memcpy(ptp_mac, connect_packet.addr, 6);
@@ -559,7 +561,9 @@ static void *ptp_connect(void *addr, int addrlen, const char *src_ptp_mac, int p
 	new_session->abort = false;
 	new_session->sending = false;
 	new_session->recving = false;
-	new_session->outstanding_data_size = 0;
+	new_session->recv_ring_buf_start = 0;
+	new_session->recv_ring_buf_used = 0;
+	new_session->bytes_till_next_header = 0;
 	*state = AEMU_POSTOFFICE_CLIENT_OK;
 	return new_session;
 }
@@ -588,7 +592,7 @@ int ptp_send(void *ptp_handle, const char *buf, int len, bool non_block){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	if (len > sizeof(session->recv_buf)){
+	if (len > AEMU_POSTOFFICE_PTP_BLOCK_MAX){
 		LOG("%s: failed sending data, data too big, %d\n", __func__, len);
 		return AEMU_POSTOFFICE_CLIENT_OUT_OF_MEMORY;
 	}
@@ -632,6 +636,92 @@ int ptp_send(void *ptp_handle, const char *buf, int len, bool non_block){
 	return AEMU_POSTOFFICE_CLIENT_OK;
 }
 
+static int consume_ring_buf(uint8_t *dst, int dst_size, const uint8_t *ring_buf, int ring_buf_size, int *ring_buf_begin, int *ring_buf_used){
+	int to_consume = dst_size > *ring_buf_used ? *ring_buf_used : dst_size;
+	for (int i = 0;i < to_consume;i++){
+		int ring_buf_offset = (*ring_buf_begin + i) % ring_buf_size;
+		dst[i] = ring_buf[ring_buf_offset];
+	}
+	*ring_buf_begin = (*ring_buf_begin + to_consume) % ring_buf_size;
+	*ring_buf_used = *ring_buf_used - to_consume;
+	return to_consume;
+}
+
+static int ptp_drain_blocks_to_ring_buf(struct ptp_session *session){
+	while(true){
+		if (session->bytes_till_next_header == 0){
+			struct aemu_postoffice_ptp_data header = {0};
+			int peek_result = native_peek(session->sock, (char *)&header, sizeof(header));
+			if (peek_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
+				return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+			}
+			if (peek_result == 0){
+				LOG("%s: remote closed the socket\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+			if (peek_result == -1){
+				LOG("%s: failed peeking header\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+			if (peek_result != sizeof(header)){
+				return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+			}
+			int recv_status = native_recv(session->sock, (char *)&header, sizeof(header));
+			if (recv_status == 0){
+				LOG("%s: remote closed the socket\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+			if (recv_status == -1){
+				LOG("%s: failed reading header\n", __func__);
+				native_close_tcp_sock(session->sock);
+				session->dead = true;
+				return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+			}
+
+			session->bytes_till_next_header = header.size;
+		}
+
+		int ring_buf_free = sizeof(session->recv_ring_buf) - session->recv_ring_buf_used;
+		int ring_buf_end = (session->recv_ring_buf_start + session->recv_ring_buf_used) % sizeof(session->recv_ring_buf);
+		int linear_size_from_end = sizeof(session->recv_ring_buf) - ring_buf_end;
+		int to_append = ring_buf_free;
+		if (to_append > session->bytes_till_next_header){
+			to_append = session->bytes_till_next_header;
+		}
+		if (to_append > linear_size_from_end){
+			to_append = linear_size_from_end;
+		}
+		if (to_append == 0){
+			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		}
+
+		int recv_status = native_recv(session->sock, &session->recv_ring_buf[ring_buf_end], to_append);
+		if (recv_status == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
+			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		}
+		if (recv_status == 0){
+			LOG("%s: remote closed the socket\n", __func__);
+			native_close_tcp_sock(session->sock);
+			session->dead = true;
+			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+		}
+		if (recv_status == -1){
+			LOG("%s: failed reading data\n", __func__);
+			native_close_tcp_sock(session->sock);
+			session->dead = true;
+			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
+		}
+		session->recv_ring_buf_used = session->recv_ring_buf_used + recv_status;
+		session->bytes_till_next_header = session->bytes_till_next_header - recv_status;
+	}
+}
+
 int ptp_recv(void *ptp_handle, char *buf, int *len, bool non_block){
 	if (ptp_handle == NULL){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
@@ -642,114 +732,33 @@ int ptp_recv(void *ptp_handle, char *buf, int *len, bool non_block){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	if (*len > sizeof(session->recv_buf)){
-		LOG("%s: failed receiving data, data too big, %d\n", __func__, *len);
-		return AEMU_POSTOFFICE_CLIENT_OUT_OF_MEMORY;
-	}
-
-	// check if we have outstanding transfer
-	if (session->outstanding_data_size != 0){
-		memcpy(buf, &session->recv_buf[session->outstanding_data_offset], session->outstanding_data_size > *len ? *len : session->outstanding_data_size);
-		if (session->outstanding_data_size > *len){
-			session->outstanding_data_size -= *len;
-			session->outstanding_data_offset += *len;
-			return AEMU_POSTOFFICE_CLIENT_SESSION_DATA_TRUNC;
-		}
-
-		*len = session->outstanding_data_size;
-		session->outstanding_data_size = 0;
-		return AEMU_POSTOFFICE_CLIENT_OK;
-	}
-
-	struct aemu_postoffice_ptp_data header = {0};
-
-	if (non_block){
-		// take a peek at the message
-		int peek_len = native_peek(session->sock, (char *)&header, sizeof(header));
-		if (peek_len == -1){
-			native_close_tcp_sock(session->sock);
-			session->dead = true;
+	while(true){
+		if (session->abort){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
-		if (peek_len != sizeof(header)){
-			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
-		}
-
-		int full_message_len = header.size + sizeof(header);
-		int min_len = full_message_len > 2048 ? 2048 : full_message_len;
-
-		peek_len = native_peek(session->sock, session->recv_buf, min_len);
-		if (peek_len == -1){
-			native_close_tcp_sock(session->sock);
-			session->dead = true;
+		int drain_result = ptp_drain_blocks_to_ring_buf(session);
+		if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 			return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 		}
-		if (peek_len != min_len){
-			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
+			if (non_block){
+				break;
+			}
+			if (session->recv_ring_buf_used != 0){
+				break;
+			}
 		}
+		// yield so that on the PSP new data can get into the recv buffer
+		delay(0);
 	}
 
-	session->recving = true;
-	int recv_status = native_recv_till_done(session->sock, (char *)&header, sizeof(header), non_block, &session->abort);
-	session->recving = false;
-	if (recv_status == NATIVE_SOCK_ABORTED){
-		// getting aborted
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-	if (recv_status == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
+	if (session->recv_ring_buf_used == 0){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
 	}
 
-	if (recv_status == 0){
-		LOG("%s: remote closed the socket\n", __func__);
-		native_close_tcp_sock(session->sock);
-		session->dead = true;
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
+	int ring_buffer_consumed = consume_ring_buf((uint8_t *)buf, *len, (uint8_t *)session->recv_ring_buf, sizeof(session->recv_ring_buf), &session->recv_ring_buf_start, &session->recv_ring_buf_used);
+	*len = ring_buffer_consumed;
 
-	if (recv_status < 0){
-		LOG("%s: failed receiving header\n", __func__);
-		native_close_tcp_sock(session->sock);
-		session->dead = true;
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (header.size > sizeof(session->recv_buf)){
-		LOG("%s: incoming data too big\n", __func__);
-		native_close_tcp_sock(session->sock);
-		session->dead = true;
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	session->recving = true;
-	recv_status = native_recv_till_done(session->sock, session->recv_buf, header.size, false, &session->abort);
-	session->recving = false;
-	if (recv_status == NATIVE_SOCK_ABORTED){
-		// getting aborted
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (recv_status == 0){
-		LOG("%s: remote closed the socket\n", __func__);
-		native_close_tcp_sock(session->sock);
-		session->dead = true;
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (recv_status < 0){
-		LOG("%s: failed receiving data\n", __func__);
-		native_close_tcp_sock(session->sock);
-		session->dead = true;
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	memcpy(buf, session->recv_buf, header.size > *len ? *len : header.size);
-	if (*len < header.size){
-		session->outstanding_data_offset = *len;
-		session->outstanding_data_size = header.size - *len;
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DATA_TRUNC;
-	}
-	*len = header.size;
 	return AEMU_POSTOFFICE_CLIENT_OK;
 }
 
@@ -815,26 +824,11 @@ int ptp_peek_next_size(void *ptp_handle){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
 
-	aemu_postoffice_ptp_data header = {0};
-	session->recving = true;
-	int peek_result = native_peek(session->sock, (char *)&header, sizeof(header));
-	session->recving = false;
-	if (peek_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
-		return 0;
-	}
-	if (session->abort){
+	int drain_result = ptp_drain_blocks_to_ring_buf(session);
+	if (drain_result == AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
 	}
+	// AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK
 
-	if (peek_result <= 0){
-		session->dead = true;
-		native_close_tcp_sock(session->sock);
-		return AEMU_POSTOFFICE_CLIENT_SESSION_DEAD;
-	}
-
-	if (peek_result != sizeof(header)){
-		return 0;
-	}
-
-	return header.size;
+	return session->recv_ring_buf_used;
 }

--- a/client/postoffice_client.exp
+++ b/client/postoffice_client.exp
@@ -13,6 +13,7 @@ PSP_EXPORT_FUNC_NID(pdp_send, 0x3)
 PSP_EXPORT_FUNC_NID(pdp_recv, 0x4)
 PSP_EXPORT_FUNC_NID(pdp_get_native_sock, 0x5)
 PSP_EXPORT_FUNC_NID(pdp_peek_next_size, 0x6)
+PSP_EXPORT_FUNC_NID(pdp_buffered_data_size, 0x7)
 
 PSP_EXPORT_FUNC_NID(ptp_listen_v4, 0x101)
 PSP_EXPORT_FUNC_NID(ptp_accept, 0x102)

--- a/client/postoffice_client.exp
+++ b/client/postoffice_client.exp
@@ -15,6 +15,7 @@ PSP_EXPORT_FUNC_NID(pdp_get_native_sock, 0x5)
 PSP_EXPORT_FUNC_NID(pdp_peek_next_size, 0x6)
 PSP_EXPORT_FUNC_NID(pdp_buffered_data_size, 0x7)
 PSP_EXPORT_FUNC_NID(pdp_send_buf_not_full, 0x8)
+PSP_EXPORT_FUNC_NID(pdp_is_dead, 0x9)
 
 PSP_EXPORT_FUNC_NID(ptp_listen_v4, 0x101)
 PSP_EXPORT_FUNC_NID(ptp_accept, 0x102)
@@ -28,6 +29,8 @@ PSP_EXPORT_FUNC_NID(ptp_listen_get_native_sock, 0x109)
 PSP_EXPORT_FUNC_NID(ptp_peek_next_size, 0x10A)
 PSP_EXPORT_FUNC_NID(ptp_send_buf_not_full, 0x10B)
 PSP_EXPORT_FUNC_NID(ptp_listen_has_request, 0x10C)
+PSP_EXPORT_FUNC_NID(ptp_is_dead, 0x10D)
+PSP_EXPORT_FUNC_NID(ptp_listen_is_dead, 0x10E)
 PSP_EXPORT_END
 
 PSP_END_EXPORTS

--- a/client/postoffice_client.exp
+++ b/client/postoffice_client.exp
@@ -14,6 +14,7 @@ PSP_EXPORT_FUNC_NID(pdp_recv, 0x4)
 PSP_EXPORT_FUNC_NID(pdp_get_native_sock, 0x5)
 PSP_EXPORT_FUNC_NID(pdp_peek_next_size, 0x6)
 PSP_EXPORT_FUNC_NID(pdp_buffered_data_size, 0x7)
+PSP_EXPORT_FUNC_NID(pdp_send_buf_not_full, 0x8)
 
 PSP_EXPORT_FUNC_NID(ptp_listen_v4, 0x101)
 PSP_EXPORT_FUNC_NID(ptp_accept, 0x102)
@@ -25,6 +26,8 @@ PSP_EXPORT_FUNC_NID(ptp_listen_close, 0x107)
 PSP_EXPORT_FUNC_NID(ptp_get_native_sock, 0x108)
 PSP_EXPORT_FUNC_NID(ptp_listen_get_native_sock, 0x109)
 PSP_EXPORT_FUNC_NID(ptp_peek_next_size, 0x10A)
+PSP_EXPORT_FUNC_NID(ptp_send_buf_not_full, 0x10B)
+PSP_EXPORT_FUNC_NID(ptp_listen_has_request, 0x10C)
 PSP_EXPORT_END
 
 PSP_END_EXPORTS

--- a/client/postoffice_client.h
+++ b/client/postoffice_client.h
@@ -52,6 +52,7 @@ int pdp_send(void *pdp_handle, const char *pdp_mac, int pdp_port, const char *bu
 int pdp_recv(void *pdp_handle, char *pdp_mac, int *pdp_port, char *buf, int *len, bool non_block);
 int pdp_peek_next_size(void *pdp_handle);
 int pdp_buffered_data_size(void *pdp_handle);
+int pdp_send_buf_not_full(void *pdp_handle);
 void *ptp_listen_v6(const struct aemu_post_office_sock6_addr *addr, const char *ptp_mac, int ptp_port, int *state);
 void *ptp_listen_v4(const struct aemu_post_office_sock_addr *addr, const char *ptp_mac, int ptp_port, int *state);
 void *ptp_accept(void *ptp_listen_handle, char *ptp_mac, int *ptp_port, bool nonblock, int *state);
@@ -62,6 +63,8 @@ int ptp_recv(void *ptp_handle, char *buf, int *len, bool non_block);
 void ptp_close(void *ptp_handle);
 void ptp_listen_close(void *ptp_listen_handle);
 int ptp_peek_next_size(void *ptp_handle);
+int ptp_send_buf_not_full(void *pdp_handle);
+int ptp_listen_has_request(void *pdp_listen_handler);
 
 int pdp_get_native_sock(void *pdp_handle);
 int ptp_get_native_sock(void *ptp_handle);

--- a/client/postoffice_client.h
+++ b/client/postoffice_client.h
@@ -51,6 +51,7 @@ void pdp_delete(void *pdp_handle);
 int pdp_send(void *pdp_handle, const char *pdp_mac, int pdp_port, const char *buf, int len, bool non_block);
 int pdp_recv(void *pdp_handle, char *pdp_mac, int *pdp_port, char *buf, int *len, bool non_block);
 int pdp_peek_next_size(void *pdp_handle);
+int pdp_buffered_data_size(void *pdp_handle);
 void *ptp_listen_v6(const struct aemu_post_office_sock6_addr *addr, const char *ptp_mac, int ptp_port, int *state);
 void *ptp_listen_v4(const struct aemu_post_office_sock_addr *addr, const char *ptp_mac, int ptp_port, int *state);
 void *ptp_accept(void *ptp_listen_handle, char *ptp_mac, int *ptp_port, bool nonblock, int *state);

--- a/client/postoffice_client.h
+++ b/client/postoffice_client.h
@@ -53,6 +53,7 @@ int pdp_recv(void *pdp_handle, char *pdp_mac, int *pdp_port, char *buf, int *len
 int pdp_peek_next_size(void *pdp_handle);
 int pdp_buffered_data_size(void *pdp_handle);
 int pdp_send_buf_not_full(void *pdp_handle);
+int pdp_is_dead(void *ptp_handle);
 void *ptp_listen_v6(const struct aemu_post_office_sock6_addr *addr, const char *ptp_mac, int ptp_port, int *state);
 void *ptp_listen_v4(const struct aemu_post_office_sock_addr *addr, const char *ptp_mac, int ptp_port, int *state);
 void *ptp_accept(void *ptp_listen_handle, char *ptp_mac, int *ptp_port, bool nonblock, int *state);
@@ -65,6 +66,7 @@ void ptp_listen_close(void *ptp_listen_handle);
 int ptp_peek_next_size(void *ptp_handle);
 int ptp_send_buf_not_full(void *pdp_handle);
 int ptp_listen_has_request(void *pdp_listen_handler);
+int ptp_is_dead(void *ptp_handle);
 
 int pdp_get_native_sock(void *pdp_handle);
 int ptp_get_native_sock(void *ptp_handle);

--- a/client/postoffice_client.h
+++ b/client/postoffice_client.h
@@ -71,6 +71,7 @@ int ptp_is_dead(void *ptp_handle);
 int pdp_get_native_sock(void *pdp_handle);
 int ptp_get_native_sock(void *ptp_handle);
 int ptp_listen_get_native_sock(void *ptp_listen_handle);
+int ptp_listen_is_dead(void *ptp_listen_handle);
 
 #ifdef __cplusplus
 }

--- a/client/postoffice_client_import.S
+++ b/client/postoffice_client_import.S
@@ -2,7 +2,7 @@
 
 #include "pspstub.s"
 
-	STUB_START "aemu_postoffice_client",0x00090011,0x00140005
+	STUB_START "aemu_postoffice_client",0x00090011,0x00170005
 	STUB_FUNC  0x1,pdp_create_v4
 	STUB_FUNC  0x2,pdp_delete
 	STUB_FUNC  0x3,pdp_send
@@ -11,6 +11,7 @@
 	STUB_FUNC  0x6,pdp_peek_next_size
 	STUB_FUNC  0x7,pdp_buffered_data_size
 	STUB_FUNC  0x8,pdp_send_buf_not_full
+	STUB_FUNC  0x9,pdp_is_dead
 
 	STUB_FUNC  0x101,ptp_listen_v4
 	STUB_FUNC  0x102,ptp_accept
@@ -24,4 +25,6 @@
 	STUB_FUNC  0x10A,ptp_peek_next_size
 	STUB_FUNC  0x10B,ptp_send_buf_not_full
 	STUB_FUNC  0x10C,ptp_listen_has_request
+	STUB_FUNC  0x10D,ptp_is_dead
+	STUB_FUNC  0x10E,ptp_listen_is_dead
 	STUB_END

--- a/client/postoffice_client_import.S
+++ b/client/postoffice_client_import.S
@@ -2,13 +2,14 @@
 
 #include "pspstub.s"
 
-	STUB_START "aemu_postoffice_client",0x00090011,0x00100005
+	STUB_START "aemu_postoffice_client",0x00090011,0x00110005
 	STUB_FUNC  0x1,pdp_create_v4
 	STUB_FUNC  0x2,pdp_delete
 	STUB_FUNC  0x3,pdp_send
 	STUB_FUNC  0x4,pdp_recv
 	STUB_FUNC  0x5,pdp_get_native_sock
 	STUB_FUNC  0x6,pdp_peek_next_size
+	STUB_FUNC  0x7,pdp_buffered_data_size
 
 	STUB_FUNC  0x101,ptp_listen_v4
 	STUB_FUNC  0x102,ptp_accept

--- a/client/postoffice_client_import.S
+++ b/client/postoffice_client_import.S
@@ -2,7 +2,7 @@
 
 #include "pspstub.s"
 
-	STUB_START "aemu_postoffice_client",0x00090011,0x00110005
+	STUB_START "aemu_postoffice_client",0x00090011,0x00140005
 	STUB_FUNC  0x1,pdp_create_v4
 	STUB_FUNC  0x2,pdp_delete
 	STUB_FUNC  0x3,pdp_send
@@ -10,6 +10,7 @@
 	STUB_FUNC  0x5,pdp_get_native_sock
 	STUB_FUNC  0x6,pdp_peek_next_size
 	STUB_FUNC  0x7,pdp_buffered_data_size
+	STUB_FUNC  0x8,pdp_send_buf_not_full
 
 	STUB_FUNC  0x101,ptp_listen_v4
 	STUB_FUNC  0x102,ptp_accept
@@ -21,4 +22,6 @@
 	STUB_FUNC  0x108,ptp_get_native_sock
 	STUB_FUNC  0x109,ptp_listen_get_native_sock
 	STUB_FUNC  0x10A,ptp_peek_next_size
+	STUB_FUNC  0x10B,ptp_send_buf_not_full
+	STUB_FUNC  0x10C,ptp_listen_has_request
 	STUB_END

--- a/client/postoffice_mem.h
+++ b/client/postoffice_mem.h
@@ -5,6 +5,7 @@
 #include "sock_impl.h"
 
 #include "postoffice_client.h"
+#include "../aemu_postoffice_packets.h"
 
 struct pdp_session{
 	char *pdp_mac[6];
@@ -12,7 +13,12 @@ struct pdp_session{
 	int sock;
 	bool dead;
 	bool abort;
-	char recv_buf[AEMU_POSTOFFICE_PDP_BLOCK_MAX];
+	char recv_ring_buf[AEMU_POSTOFFICE_PDP_BLOCK_MAX + sizeof(aemu_postoffice_pdp)];
+	int recv_ring_buf_start;
+	int recv_ring_buf_used;
+	int buffered_data;
+	int bytes_till_next_header;
+	int last_block_size;
 	bool recving;
 	bool sending;
 };

--- a/client/postoffice_mem.h
+++ b/client/postoffice_mem.h
@@ -32,9 +32,10 @@ struct ptp_session{
 	int sock;
 	bool dead;
 	bool abort;
-	char recv_buf[AEMU_POSTOFFICE_PTP_BLOCK_MAX];
-	int outstanding_data_size;
-	int outstanding_data_offset;
+	char recv_ring_buf[AEMU_POSTOFFICE_PTP_BLOCK_MAX];
+	int recv_ring_buf_start;
+	int recv_ring_buf_used;
+	int bytes_till_next_header;
 	bool recving;
 	bool sending;
 };

--- a/client/sock_impl.h
+++ b/client/sock_impl.h
@@ -32,6 +32,7 @@ int native_connect_tcp_sock(void *addr, int addrlen);
 int native_close_tcp_sock(int sock);
 int native_send_till_done(int fd, const char *buf, int len, bool non_block, bool *abort);
 int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abort);
+int native_recv(int fd, char *buf, int len);
 int native_peek(int fd, char *buf, int len);
 
 #endif

--- a/client/sock_impl.h
+++ b/client/sock_impl.h
@@ -35,5 +35,6 @@ int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abor
 int native_recv(int fd, char *buf, int len);
 int native_peek(int fd, char *buf, int len);
 bool native_send_buf_not_full(int fd);
+bool native_hung_up(int fd);
 
 #endif

--- a/client/sock_impl.h
+++ b/client/sock_impl.h
@@ -34,5 +34,6 @@ int native_send_till_done(int fd, const char *buf, int len, bool non_block, bool
 int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abort);
 int native_recv(int fd, char *buf, int len);
 int native_peek(int fd, char *buf, int len);
+bool native_send_buf_not_full(int fd);
 
 #endif

--- a/client/sock_impl_linux.c
+++ b/client/sock_impl_linux.c
@@ -177,19 +177,35 @@ int native_send_till_done(int fd, const char *buf, int len, bool non_block, bool
 	return write_offset;
 }
 
+int native_recv(int fd, char *buf, int len){
+	int recv_status = recv(fd, buf, len, 0);
+	if (recv_status == 0){
+		return recv_status;
+	}
+	if (recv_status < 0){
+		int err = errno;
+		if (err == EAGAIN || err == EWOULDBLOCK){
+			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		}
+		// Other errors
+		LOG("%s: failed receving, %s\n", __func__, strerror(errno));
+		return recv_status;
+	}
+	return recv_status;
+}
+
 int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abort){
 	int read_offset = 0;
 	while(read_offset != len){
 		if (*abort){
 			return NATIVE_SOCK_ABORTED;
 		}
-		int recv_status = recv(fd, &buf[read_offset], len - read_offset, 0);
+		int recv_status = native_recv(fd, &buf[read_offset], len - read_offset);
 		if (recv_status == 0){
 			return recv_status;
 		}
 		if (recv_status < 0){
-			int err = errno;
-			if (err == EAGAIN || err == EWOULDBLOCK){
+			if (recv_status == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
 				if (non_block && read_offset == 0){
 					return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
 				}
@@ -197,8 +213,6 @@ int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abor
 				sleep(0);
 				continue;
 			}
-			// Other errors
-			LOG("%s: failed receving, %s\n", __func__, strerror(errno));
 			return recv_status;
 		}
 		read_offset += recv_status;

--- a/client/sock_impl_linux.c
+++ b/client/sock_impl_linux.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <time.h>
+#include <poll.h>
 
 #include <string.h>
 #include <stdio.h>
@@ -238,4 +239,16 @@ int native_peek(int fd, char *buf, int len){
 		return -1;
 	}
 	return read_result;
+}
+
+bool native_send_buf_not_full(int fd){
+	struct pollfd pfd;
+	pfd.fd = fd;
+	pfd.events = POLLWRNORM;
+	pfd.revents = 0;
+	poll(&pfd, 1, 0);
+	if (pfd.revents & POLLWRNORM){
+		return true;
+	}
+	return false;
 }

--- a/client/sock_impl_linux.c
+++ b/client/sock_impl_linux.c
@@ -247,8 +247,22 @@ bool native_send_buf_not_full(int fd){
 	pfd.events = POLLWRNORM;
 	pfd.revents = 0;
 	poll(&pfd, 1, 0);
+	if (pfd.revents & POLLHUP){
+		return false;
+	}
 	if (pfd.revents & POLLWRNORM){
 		return true;
 	}
 	return false;
+}
+
+bool native_hung_up(int fd){
+	uint8_t buf;
+	int peek_result = native_peek(fd, &buf, sizeof(buf));
+	if (peek_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK ||
+		peek_result == sizeof(buf)
+	){
+		return false;
+	}
+	return true;
 }

--- a/client/sock_impl_psp.c
+++ b/client/sock_impl_psp.c
@@ -156,6 +156,8 @@ typedef struct SceNetInetPollfd {
 } SceNetInetPollfd;
 
 #define INET_POLLWRNORM 0x0004
+#define INET_POLLRDNORM 0x0040
+#define INET_POLLHUP 0x0010
 
 int sceNetInetPoll(struct SceNetInetPollfd *fds, size_t nfds, int timeout);
 
@@ -169,4 +171,15 @@ bool native_send_buf_not_full(int fd){
 		return true;
 	}
 	return false;
+}
+
+bool native_hung_up(int fd){
+	uint8_t buf;
+	int peek_result = native_peek(fd, &buf, sizeof(buf));
+	if (peek_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK ||
+		peek_result == sizeof(buf)
+	){
+		return false;
+	}
+	return true;
 }

--- a/client/sock_impl_psp.c
+++ b/client/sock_impl_psp.c
@@ -84,19 +84,35 @@ int native_send_till_done(int fd, const char *buf, int len, bool non_block, bool
 	return write_offset;
 }
 
+int native_recv(int fd, char *buf, int len){
+	int recv_status = sceNetInetRecv(fd, buf, len, MSG_DONTWAIT);
+	if (recv_status == 0){
+		return recv_status;
+	}
+	if (recv_status < 0){
+		int err = sceNetInetGetErrno();
+		if (err == EAGAIN || err == EWOULDBLOCK){
+			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		}
+		// Other errors
+		LOG("%s: failed receving, 0x%x\n", __func__, err);
+		return recv_status;
+	}
+	return recv_status;
+}
+
 int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abort){
 	int read_offset = 0;
 	while(read_offset != len){
 		if (*abort){
 			return NATIVE_SOCK_ABORTED;
 		}
-		int recv_status = sceNetInetRecv(fd, &buf[read_offset], len - read_offset, MSG_DONTWAIT);
+		int recv_status = native_recv(fd, &buf[read_offset], len - read_offset);
 		if (recv_status == 0){
 			return recv_status;
 		}
 		if (recv_status < 0){
-			int err = sceNetInetGetErrno();
-			if (err == EAGAIN || err == EWOULDBLOCK){
+			if (recv_status == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
 				if (non_block && read_offset == 0){
 					sceKernelDelayThread(0);
 					return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
@@ -105,8 +121,6 @@ int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abor
 				sceKernelDelayThread(0);
 				continue;
 			}
-			// Other errors
-			LOG("%s: failed receving, 0x%x\n", __func__, err);
 			return recv_status;
 		}
 		read_offset += recv_status;

--- a/client/sock_impl_psp.c
+++ b/client/sock_impl_psp.c
@@ -147,3 +147,26 @@ int native_peek(int fd, char *buf, int len){
 	}
 	return read_result;
 }
+
+// bits from aemu pspnet_inet.h
+typedef struct SceNetInetPollfd {
+	int fd;
+	short events;
+	short revents;
+} SceNetInetPollfd;
+
+#define INET_POLLWRNORM 0x0004
+
+int sceNetInetPoll(struct SceNetInetPollfd *fds, size_t nfds, int timeout);
+
+bool native_send_buf_not_full(int fd){
+	struct SceNetInetPollfd pfd;
+	pfd.fd = fd;
+	pfd.events = INET_POLLWRNORM;
+	pfd.revents = 0;
+	sceNetInetPoll(&pfd, 1, 0);
+	if (pfd.revents & INET_POLLWRNORM){
+		return true;
+	}
+	return false;
+}

--- a/client/sock_impl_windows.c
+++ b/client/sock_impl_windows.c
@@ -227,3 +227,15 @@ int native_peek(int fd, char *buf, int len){
 	}
 	return read_result;
 }
+
+bool native_send_buf_not_full(int fd){
+	WSAPOLLFD pfd;
+	pfd.fd = fd;
+	pfd.events = POLLWRNORM;
+	pfd.revents = 0;
+	WSAPoll(&pfd, 1, 0);
+	if (pfd.revents & POLLWRNORM){
+		return true;
+	}
+	return false;
+}

--- a/client/sock_impl_windows.c
+++ b/client/sock_impl_windows.c
@@ -165,19 +165,35 @@ int native_send_till_done(int fd, const char *buf, int len, bool non_block, bool
 	return write_offset;
 }
 
+int native_recv(int fd, char *buf, int len){
+	int recv_status = recv(fd, buf, len, 0);
+	if (recv_status == 0){
+		return recv_status;
+	}
+	if (recv_status < 0){
+		int err = WSAGetLastError();
+		if (err == WSAEWOULDBLOCK || err == WSAEINPROGRESS){
+			return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
+		}
+		// Other errors
+		LOG("%s: failed receving, %d\n", __func__, err);
+		return recv_status;
+	}
+	return recv_status;
+}
+
 int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abort){
 	int read_offset = 0;
 	while(read_offset != len){
 		if (*abort){
 			return NATIVE_SOCK_ABORTED;
 		}
-		int recv_status = recv(fd, &buf[read_offset], len - read_offset, 0);
+		int recv_status = native_recv(fd, &buf[read_offset], len - read_offset);
 		if (recv_status == 0){
 			return recv_status;
 		}
 		if (recv_status < 0){
-			int err = WSAGetLastError();
-			if (err == WSAEWOULDBLOCK || err == WSAEINPROGRESS){
+			if (recv_status == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
 				if (non_block && read_offset == 0){
 					return AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK;
 				}
@@ -185,8 +201,6 @@ int native_recv_till_done(int fd, char *buf, int len, bool non_block, bool *abor
 				Sleep(0);
 				continue;
 			}
-			// Other errors
-			LOG("%s: failed receving, %d\n", __func__, err);
 			return recv_status;
 		}
 		read_offset += recv_status;

--- a/client/sock_impl_windows.c
+++ b/client/sock_impl_windows.c
@@ -234,8 +234,22 @@ bool native_send_buf_not_full(int fd){
 	pfd.events = POLLWRNORM;
 	pfd.revents = 0;
 	WSAPoll(&pfd, 1, 0);
+	if (pfd.revents & POLLHUP){
+		return false;
+	}
 	if (pfd.revents & POLLWRNORM){
 		return true;
 	}
 	return false;
+}
+
+bool native_hung_up(int fd){
+	uint8_t buf;
+	int peek_result = native_peek(fd, &buf, sizeof(buf));
+	if (peek_result == AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK ||
+		peek_result == sizeof(buf)
+	){
+		return false;
+	}
+	return true;
 }

--- a/client/test.c
+++ b/client/test.c
@@ -547,7 +547,11 @@ void test_ptp(){
 			LOG("%s: receiving from b accept to a has bad data size\n", __func__);
 			exit(1);
 		}
-		if (memcmp(recv_buf, test_data, sizeof(test_data)) != 0){
+		if (memcmp(recv_buf_2, test_data, sizeof(test_data)) != 0){
+			LOG("%s: receiving from b accept to a has bad data\n", __func__);
+			exit(1);
+		}
+		if (memcmp(&recv_buf_2[sizeof(test_data)], test_data, sizeof(test_data)) != 0){
 			LOG("%s: receiving from b accept to a has bad data\n", __func__);
 			exit(1);
 		}

--- a/client/test.c
+++ b/client/test.c
@@ -77,10 +77,19 @@ void test_pdp(){
 		exit(1);
 	}
 
+	if (pdp_is_dead(pdp_handle_a)){
+		LOG("%s: pdp session is somehow dead already\n", __func__);
+		exit(1);
+	}
+
 	int dead_len = 0;
 	int dead_status = pdp_recv(pdp_handle_a_replace, NULL, NULL, NULL, &dead_len, false);
 	if (dead_status != AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 		LOG("%s: expected dead session is not dead!\n", __func__);
+		exit(1);
+	}
+	if (!pdp_is_dead(pdp_handle_a_replace)){
+		LOG("%s: pdp session is somehow not dead yet\n", __func__);
 		exit(1);
 	}
 
@@ -345,6 +354,11 @@ void test_ptp(){
 		exit(1);
 	}
 
+	if (ptp_listen_is_dead(listen_handle_a)){
+		LOG("%s: a's listen handle is somehow already dead\n", __func__);
+		exit(1);
+	}
+
 	void *listen_handle_b = ptp_listen_v4(&local_addr, ptp_mac_b, port_b, &state);
 	if (listen_handle_b == NULL){
 		LOG("%s: failed opening listen handle for b\n", __func__);
@@ -395,6 +409,11 @@ void test_ptp(){
 	void *a_to_b = ptp_connect_v4(&local_addr, ptp_mac_a, port_a, ptp_mac_b, port_b, &state);
 	if (state != AEMU_POSTOFFICE_CLIENT_OK){
 		LOG("%s: failed connecting from a to b\n", __func__);
+		exit(1);
+	}
+
+	if (ptp_is_dead(a_to_b)){
+		LOG("%s: a connect to be handle is somehow already dead\n", __func__);
 		exit(1);
 	}
 

--- a/client/test.c
+++ b/client/test.c
@@ -66,9 +66,14 @@ void test_pdp(){
 	sleep(1);
 
 	void *pdp_handle_a = pdp_create_v4(&local_addr, pdp_mac_a, port_a, &state);
-	
+
 	if (pdp_handle_a == NULL){
 		LOG("%s: failed creating pdp socket\n", __func__);
+		exit(1);
+	}
+
+	if (!pdp_send_buf_not_full(pdp_handle_a)){
+		LOG("%s: pdp send buffer is somehow already full\n", __func__);
 		exit(1);
 	}
 
@@ -297,10 +302,17 @@ struct connection_accept_task{
 
 void *accept_ptp_connection(void *arg){
 	struct connection_accept_task *task = (struct connection_accept_task *)arg;
-	void *listen_handle = *(void **)arg;
 	int state = 0;
 	int port = 0;
 	char mac[6];
+
+	sleep(1);
+	int has_listen_request = ptp_listen_has_request(task->listen_handle);
+	if (has_listen_request == 0){
+		LOG("%s: listen request expceted but is not ready\n", __func__);
+		exit(1);
+	}
+
 	void *accept_handle = ptp_accept(task->listen_handle, mac, &port, false, &state);
 
 	if (port != task->expected_port){
@@ -347,13 +359,23 @@ void test_ptp(){
 		exit(1);
 	}
 
+	int has_listen_request = ptp_listen_has_request(listen_handle_a);
+	if (has_listen_request != 0){
+		LOG("%s: listen handle a unexpectly already has a listen request, %d\n", __func__, has_listen_request);
+		exit(1);
+	}
+
 	ptp_accept(listen_handle_b, mac, &port, true, &state);
 	if (state != AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
 		LOG("%s: unexpected state %d on non block accept\n", __func__, state);
 		exit(1);
-	}	
+	}
 
-	sleep(2);
+	has_listen_request = ptp_listen_has_request(listen_handle_b);
+	if (has_listen_request != 0){
+		LOG("%s: listen handle b unexpectly already has a listen request, %d\n", __func__, has_listen_request);
+		exit(1);
+	}
 
 	pthread_t accept_thread_a;
 	pthread_t accept_thread_b;
@@ -367,15 +389,16 @@ void test_ptp(){
 		.expected_port = port_a
 	};
 	memcpy(task_b.expected_mac, ptp_mac_a, 6);
-	pthread_create(&accept_thread_a, NULL, accept_ptp_connection, &task_a);
-	pthread_create(&accept_thread_b, NULL, accept_ptp_connection, &task_b);
 
+
+	pthread_create(&accept_thread_b, NULL, accept_ptp_connection, &task_b);
 	void *a_to_b = ptp_connect_v4(&local_addr, ptp_mac_a, port_a, ptp_mac_b, port_b, &state);
 	if (state != AEMU_POSTOFFICE_CLIENT_OK){
 		LOG("%s: failed connecting from a to b\n", __func__);
 		exit(1);
 	}
 
+	pthread_create(&accept_thread_a, NULL, accept_ptp_connection, &task_a);
 	void *b_to_a = ptp_connect_v4(&local_addr, ptp_mac_b, port_b, ptp_mac_a, port_a, &state);
 	if (state != AEMU_POSTOFFICE_CLIENT_OK){
 		LOG("%s: failed connecting from b to a\n", __func__);
@@ -386,6 +409,11 @@ void test_ptp(){
 	void *accept_handle_b;
 	pthread_join(accept_thread_a, &accept_handle_a);
 	pthread_join(accept_thread_b, &accept_handle_b);
+
+	if (!ptp_send_buf_not_full(a_to_b)){
+		LOG("%s: ptp send buffer is somehow already full\n", __func__);
+		exit(1);
+	}
 
 	if (accept_handle_a == NULL){
 		LOG("%s: failed accepting connection from b to a\n", __func__);

--- a/client/test.c
+++ b/client/test.c
@@ -82,14 +82,15 @@ void test_pdp(){
 		exit(1);
 	}
 
+	sleep(1);
+	if (!pdp_is_dead(pdp_handle_a_replace)){
+		LOG("%s: pdp session is somehow not dead yet\n", __func__);
+		exit(1);
+	}
 	int dead_len = 0;
 	int dead_status = pdp_recv(pdp_handle_a_replace, NULL, NULL, NULL, &dead_len, false);
 	if (dead_status != AEMU_POSTOFFICE_CLIENT_SESSION_DEAD){
 		LOG("%s: expected dead session is not dead!\n", __func__);
-		exit(1);
-	}
-	if (!pdp_is_dead(pdp_handle_a_replace)){
-		LOG("%s: pdp session is somehow not dead yet\n", __func__);
 		exit(1);
 	}
 
@@ -351,6 +352,11 @@ void test_ptp(){
 	void *listen_handle_a = ptp_listen_v4(&local_addr, ptp_mac_a, port_a, &state);
 	if (listen_handle_a == NULL){
 		LOG("%s: failed opening listen handle for a\n", __func__);
+		exit(1);
+	}
+
+	if (ptp_listen_is_dead(listen_handle_a)){
+		LOG("%s: listen session for a is somehow already dead\n", __func__);
 		exit(1);
 	}
 

--- a/client/test.c
+++ b/client/test.c
@@ -95,175 +95,193 @@ void test_pdp(){
 
 	sleep(1);
 
-	char test_data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-	int send_status = pdp_send(pdp_handle_a, pdp_mac_b, port_b, test_data, sizeof(test_data), false);
-	if (send_status != 0){
-		LOG("%s: failed sending pdp packet from a to b, %d\n", __func__, send_status);
-		exit(1);
-	}
-
-	send_status = pdp_send(pdp_handle_b, pdp_mac_c, port_c, test_data, sizeof(test_data), false);
-	if (send_status != 0){
-		LOG("%s: failed sending pdp packet from b to c, %d\n", __func__, send_status);
-		exit(1);
-	}
-
-	sleep(1);
-	int next_size = pdp_peek_next_size(pdp_handle_b);
-	if (next_size != sizeof(test_data)){
-		LOG("%s: failed peeking pdp size, expected %lu, got %d\n", __func__, sizeof(test_data), next_size);
-		exit(1);
-	}
-
-	char recv_buf[sizeof(test_data)];
-	char incoming_mac[6];
-	int incoming_port;
-	int len = sizeof(recv_buf);
-	int recv_status = pdp_recv(pdp_handle_b, incoming_mac, &incoming_port, recv_buf, &len, false);
-	if (recv_status != 0){
-		LOG("%s: receive failed from a to b, %d\n", __func__, recv_status);
-		exit(1);
-	}
-
-	if (len != sizeof(recv_buf)){
-		LOG("%s: bad length of received data from a to b\n", __func__);
-		exit(1);
-	}
-
-	if (memcmp(incoming_mac, pdp_mac_a, 6) != 0){
-		LOG("%s: bad mac address from a to b\n", __func__);
-		exit(1);
-	}
-
-	if (incoming_port != port_a){
-		LOG("%s: bad incoming port %d from a to b, expected %d\n", __func__, incoming_port, port_a);
-		exit(1);
-	}
-
-	if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
-		LOG("%s: bad data received from a to b:\n", __func__);
-		for(int i = 0;i < sizeof(test_data);i++){
-			LOG("%d ", recv_buf[i]);
+	for (int i = 0;i < 5;i++){
+		// make sure to test the ring buffers
+		char test_data[AEMU_POSTOFFICE_PDP_BLOCK_MAX / 3];
+		for (int j = 0;j < sizeof(test_data);j++){
+			test_data[j] = i + j;
 		}
-		LOG("\n");
-		exit(1);
-	}
-
-	
-	len = sizeof(recv_buf);
-	recv_status = pdp_recv(pdp_handle_c, incoming_mac, &incoming_port, recv_buf, &len, false);
-	if (recv_status != 0){
-		LOG("%s: receive failed from b to c, %d\n", __func__, recv_status);
-		exit(1);
-	}
-
-	if (len != sizeof(recv_buf)){
-		LOG("%s: bad length of received data from b to c\n", __func__);
-		exit(1);
-	}
-
-	if (memcmp(incoming_mac, pdp_mac_b, 6) != 0){
-		LOG("%s: bad mac address from b to c\n", __func__);
-		exit(1);
-	}
-
-	if (incoming_port != port_b){
-		LOG("%s: bad incoming port %d from b to c, expected %d\n", __func__, incoming_port, port_b);
-		exit(1);
-	}
-
-	if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
-		LOG("%s: bad data received from b to c:\n", __func__);
-		for(int i = 0;i < sizeof(test_data);i++){
-			LOG("%d ", recv_buf[i]);
+		int send_status = 0;
+		for (int j = 0;j < 2;j++){
+			int send_status = pdp_send(pdp_handle_a, pdp_mac_b, port_b, test_data, sizeof(test_data), false);
+			if (send_status != 0){
+				LOG("%s: failed sending pdp packet from a to b, %d\n", __func__, send_status);
+				exit(1);
+			}
 		}
-		LOG("\n");
-		exit(1);
-	}
 
-	sleep(1);
-
-	send_status = pdp_send(pdp_handle_a, pdp_mac_c, port_c, test_data, sizeof(test_data), false);
-	if (send_status != 0){
-		LOG("%s: failed sending pdp packet from a to c, %d\n", __func__, send_status);
-		exit(1);
-	}
-
-	len = sizeof(recv_buf);
-	recv_status = pdp_recv(pdp_handle_c, incoming_mac, &incoming_port, recv_buf, &len, false);
-	if (recv_status != 0){
-		LOG("%s: receive failed from a to c, %d\n", __func__, recv_status);
-		exit(1);
-	}
-
-	if (len != sizeof(recv_buf)){
-		LOG("%s: bad length of received data from a to c\n", __func__);
-		exit(1);
-	}
-
-	if (memcmp(incoming_mac, pdp_mac_a, 6) != 0){
-		LOG("%s: bad mac address from a to c\n", __func__);
-		exit(1);
-	}
-
-	if (incoming_port != port_a){
-		LOG("%s: bad incoming port %d from a to c, expected %d\n", __func__, incoming_port, port_a);
-		exit(1);
-	}
-
-	if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
-		LOG("%s: bad data received from a to c:\n", __func__);
-		for(int i = 0;i < sizeof(test_data);i++){
-			LOG("%d ", recv_buf[i]);
+		send_status = pdp_send(pdp_handle_b, pdp_mac_c, port_c, test_data, sizeof(test_data), false);
+		if (send_status != 0){
+			LOG("%s: failed sending pdp packet from b to c, %d\n", __func__, send_status);
+			exit(1);
 		}
-		LOG("\n");
-		exit(1);
-	}
 
-	len = sizeof(recv_buf);
-	recv_status = pdp_recv(pdp_handle_c, incoming_mac, &incoming_port, recv_buf, &len, true);
-	if (recv_status != AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
-		LOG("%s: expected would block status for recv, got %d instead\n", __func__, recv_status);
-		exit(1);
-	}
+		sleep(1);
 
-	send_status = pdp_send(pdp_handle_c, pdp_mac_a, port_a, test_data, sizeof(test_data), true);
-	if (send_status != 0){
-		LOG("%s: failed sending pdp packet from c to a, %d\n", __func__, send_status);
-		exit(1);
-	}
-
-	sleep(1);
-
-	len = sizeof(recv_buf);
-	recv_status = pdp_recv(pdp_handle_a, incoming_mac, &incoming_port, recv_buf, &len, true);
-	if (recv_status != 0){
-		LOG("%s: receive failed from c to a, %d\n", __func__, recv_status);
-		exit(1);
-	}
-
-	if (len != sizeof(recv_buf)){
-		LOG("%s: bad length of received data from c to a\n", __func__);
-		exit(1);
-	}
-
-	if (memcmp(incoming_mac, pdp_mac_c, 6) != 0){
-		LOG("%s: bad mac address from c to a\n", __func__);
-		exit(1);
-	}
-
-	if (incoming_port != port_c){
-		LOG("%s: bad incoming port %d from c to a, expected %d\n", __func__, incoming_port, port_c);
-		exit(1);
-	}
-
-	if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
-		LOG("%s: bad data received from c to a:\n", __func__);
-		for(int i = 0;i < sizeof(test_data);i++){
-			LOG("%d ", recv_buf[i]);
+		int buffered_size = pdp_buffered_data_size(pdp_handle_b);
+		if (buffered_size != sizeof(test_data) * 2){
+			LOG("%s: failed getting buffered data size, expected %lu, got %d\n", __func__, sizeof(test_data) * 2, buffered_size);
+			exit(1);
 		}
-		LOG("\n");
-		exit(1);
+
+		char recv_buf[sizeof(test_data)];
+		char incoming_mac[6];
+		int incoming_port;
+		int len = 0;
+		int recv_status = 0;
+		for (int j = 0;j < 2;j++){
+			int next_size = pdp_peek_next_size(pdp_handle_b);
+			if (next_size != sizeof(test_data)){
+				LOG("%s: failed peeking pdp size, expected %lu, got %d\n", __func__, sizeof(test_data), next_size);
+				exit(1);
+			}
+			len = sizeof(recv_buf);
+			int recv_status = pdp_recv(pdp_handle_b, incoming_mac, &incoming_port, recv_buf, &len, false);
+			if (recv_status != 0){
+				LOG("%s: receive failed from a to b, %d\n", __func__, recv_status);
+				exit(1);
+			}
+
+			if (len != sizeof(recv_buf)){
+				LOG("%s: bad length of received data from a to b\n", __func__);
+				exit(1);
+			}
+
+			if (memcmp(incoming_mac, pdp_mac_a, 6) != 0){
+				LOG("%s: bad mac address from a to b\n", __func__);
+				exit(1);
+			}
+
+			if (incoming_port != port_a){
+				LOG("%s: bad incoming port %d from a to b, expected %d\n", __func__, incoming_port, port_a);
+				exit(1);
+			}
+
+			if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
+				LOG("%s: bad data received from a to b:\n", __func__);
+				for(int i = 0;i < sizeof(test_data);i++){
+					LOG("%d ", recv_buf[i]);
+				}
+				LOG("\n");
+				exit(1);
+			}
+		}
+
+		len = sizeof(recv_buf);
+		recv_status = pdp_recv(pdp_handle_c, incoming_mac, &incoming_port, recv_buf, &len, false);
+		if (recv_status != 0){
+			LOG("%s: receive failed from b to c, %d\n", __func__, recv_status);
+			exit(1);
+		}
+
+		if (len != sizeof(recv_buf)){
+			LOG("%s: bad length of received data from b to c\n", __func__);
+			exit(1);
+		}
+
+		if (memcmp(incoming_mac, pdp_mac_b, 6) != 0){
+			LOG("%s: bad mac address from b to c\n", __func__);
+			exit(1);
+		}
+
+		if (incoming_port != port_b){
+			LOG("%s: bad incoming port %d from b to c, expected %d\n", __func__, incoming_port, port_b);
+			exit(1);
+		}
+
+		if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
+			LOG("%s: bad data received from b to c:\n", __func__);
+			for(int i = 0;i < sizeof(test_data);i++){
+				LOG("%d ", recv_buf[i]);
+			}
+			LOG("\n");
+			exit(1);
+		}
+
+		sleep(1);
+
+		send_status = pdp_send(pdp_handle_a, pdp_mac_c, port_c, test_data, sizeof(test_data), false);
+		if (send_status != 0){
+			LOG("%s: failed sending pdp packet from a to c, %d\n", __func__, send_status);
+			exit(1);
+		}
+
+		len = sizeof(recv_buf);
+		recv_status = pdp_recv(pdp_handle_c, incoming_mac, &incoming_port, recv_buf, &len, false);
+		if (recv_status != 0){
+			LOG("%s: receive failed from a to c, %d\n", __func__, recv_status);
+			exit(1);
+		}
+
+		if (len != sizeof(recv_buf)){
+			LOG("%s: bad length of received data from a to c\n", __func__);
+			exit(1);
+		}
+
+		if (memcmp(incoming_mac, pdp_mac_a, 6) != 0){
+			LOG("%s: bad mac address from a to c\n", __func__);
+			exit(1);
+		}
+
+		if (incoming_port != port_a){
+			LOG("%s: bad incoming port %d from a to c, expected %d\n", __func__, incoming_port, port_a);
+			exit(1);
+		}
+
+		if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
+			LOG("%s: bad data received from a to c:\n", __func__);
+			for(int i = 0;i < sizeof(test_data);i++){
+				LOG("%d ", recv_buf[i]);
+			}
+			LOG("\n");
+			exit(1);
+		}
+
+		len = sizeof(recv_buf);
+		recv_status = pdp_recv(pdp_handle_c, incoming_mac, &incoming_port, recv_buf, &len, true);
+		if (recv_status != AEMU_POSTOFFICE_CLIENT_SESSION_WOULD_BLOCK){
+			LOG("%s: expected would block status for recv, got %d instead\n", __func__, recv_status);
+			exit(1);
+		}
+
+		send_status = pdp_send(pdp_handle_c, pdp_mac_a, port_a, test_data, sizeof(test_data), true);
+		if (send_status != 0){
+			LOG("%s: failed sending pdp packet from c to a, %d\n", __func__, send_status);
+			exit(1);
+		}
+
+		sleep(1);
+
+		len = sizeof(recv_buf);
+		recv_status = pdp_recv(pdp_handle_a, incoming_mac, &incoming_port, recv_buf, &len, true);
+		if (recv_status != 0){
+			LOG("%s: receive failed from c to a, %d\n", __func__, recv_status);
+			exit(1);
+		}
+
+		if (len != sizeof(recv_buf)){
+			LOG("%s: bad length of received data from c to a\n", __func__);
+			exit(1);
+		}
+
+		if (memcmp(incoming_mac, pdp_mac_c, 6) != 0){
+			LOG("%s: bad mac address from c to a\n", __func__);
+			exit(1);
+		}
+
+		if (incoming_port != port_c){
+			LOG("%s: bad incoming port %d from c to a, expected %d\n", __func__, incoming_port, port_c);
+			exit(1);
+		}
+
+		if (memcmp(test_data, recv_buf, sizeof(test_data)) != 0){
+			LOG("%s: bad data received from c to a:\n", __func__);
+			for(int i = 0;i < sizeof(test_data);i++){
+				LOG("%d ", recv_buf[i]);
+			}
+			LOG("\n");
+			exit(1);
+		}
 	}
 
 	pdp_delete(pdp_handle_a);

--- a/client/test.c
+++ b/client/test.c
@@ -398,7 +398,12 @@ void test_ptp(){
 	}
 
 	for (int i = 0; i < 5;i++){
-		char test_data[] = {1 + i, 2 + i, 3 + i, 4, 5, 6, 7, 8, 9, 10};
+		// make sure to test the ring buffer
+		char test_data[AEMU_POSTOFFICE_PTP_BLOCK_MAX / 3];
+		for (int j = 0;j < sizeof(test_data);j++){
+			test_data[j] = j + i;
+		}
+		char recv_buf[sizeof(test_data)];
 
 		int send_status = ptp_send(accept_handle_a, test_data, sizeof(test_data), false);
 		if (send_status != 0){
@@ -460,15 +465,15 @@ void test_ptp(){
 		recv_size = sizeof(recv_buf);
 		recv_status = ptp_recv(a_to_b, recv_buf, &recv_size, false);
 		if (recv_status != 0){
-			LOG("%s: failed receiving from b accept to a\n", __func__);
+			LOG("%s: failed receiving from a connect to b\n", __func__);
 			exit(1);
 		}
 		if (memcmp(recv_buf, test_data, sizeof(test_data)) != 0){
-			LOG("%s: receiving from b accept to a has bad data\n", __func__);
+			LOG("%s: receiving from a connect to b has bad data\n", __func__);
 			exit(1);
 		}
 		if (recv_size != sizeof(recv_buf)){
-			LOG("%s: receiving from b accept to a has bad data size\n", __func__);
+			LOG("%s: receiving from a connect to b has bad data size\n", __func__);
 			exit(1);
 		}
 
@@ -477,7 +482,6 @@ void test_ptp(){
 			LOG("%s: failed sending from a connect to b\n", __func__);
 			exit(1);
 		}
-
 
 		for (int j = 0;j < sizeof(recv_buf);j++){
 			recv_size = 1;
@@ -494,6 +498,39 @@ void test_ptp(){
 
 		if (memcmp(recv_buf, test_data, sizeof(test_data)) != 0){
 			LOG("%s: receiving from a connect to b has bad data\n", __func__);
+			exit(1);
+		}
+
+		send_status = ptp_send(a_to_b, test_data, sizeof(test_data), false);
+		if (send_status != 0){
+			LOG("%s: failed sending from a connect to b\n", __func__);
+			exit(1);
+		}
+		send_status = ptp_send(a_to_b, test_data, sizeof(test_data), false);
+		if (send_status != 0){
+			LOG("%s: failed sending from a connect to b\n", __func__);
+			exit(1);
+		}
+
+		sleep(1);
+		next_size = ptp_peek_next_size(accept_handle_b);
+		if (next_size != sizeof(test_data) * 2){
+			LOG("%s: failed peeking ptp size during stream test, expected %lu, got %d\n", __func__, sizeof(test_data) * 2, next_size);
+			exit(1);
+		}
+		char recv_buf_2[sizeof(recv_buf) * 2];
+		recv_size = sizeof(recv_buf_2);
+		recv_status = ptp_recv(accept_handle_b, recv_buf_2, &recv_size, false);
+		if (recv_status != 0){
+			LOG("%s: failed receiving from b accept to a\n", __func__);
+			exit(1);
+		}
+		if (recv_size != sizeof(recv_buf_2)){
+			LOG("%s: receiving from b accept to a has bad data size\n", __func__);
+			exit(1);
+		}
+		if (memcmp(recv_buf, test_data, sizeof(test_data)) != 0){
+			LOG("%s: receiving from b accept to a has bad data\n", __func__);
 			exit(1);
 		}
 	}

--- a/server_cpp/session.cpp
+++ b/server_cpp/session.cpp
@@ -62,15 +62,17 @@ PendingSessionPumpStatus PendingSession::pump(std::map<std::string, Session> &gl
 	}
 	if (recv_status < 0){
 		int error = native_get_last_socket_error();
-		if (native_error_is_would_block(error)){
-			return PendingSessionPumpStatus::SUCCESS;
+		if (!native_error_is_would_block(error)){
+			LOG("%s: client %s has socket error 0x%x during init\n", __func__, this->client_addr.c_str(), error);
+			native_close(this->sock_fd);
+			return PendingSessionPumpStatus::SOCKET_CLOSED;
 		}
-		LOG("%s: client %s has socket error 0x%x during init\n", __func__, this->client_addr.c_str(), error);
-		native_close(this->sock_fd);
-		return PendingSessionPumpStatus::SOCKET_CLOSED;
+	}
+	if (recv_status > 0){
+		// can be <0 if we got a would block, which happens during connect wait
+		init_data_buffer.append(buf, recv_status);
 	}
 
-	init_data_buffer.append(buf, recv_status);
 	if (init_data_buffer.length() >= sizeof(aemu_postoffice_init)){
 		const aemu_postoffice_init *init = (const aemu_postoffice_init *)init_data_buffer.data();
 		switch(init->init_type){


### PR DESCRIPTION
Currently PTP recv and size peek exhibits quite block-like behavior, where data from a server sending block must be all received until data from the next server send block can be received.

This PR adds a ring buffer so that receiving is more stream like. This is to address these potential issues from the current implementation:
- Game does tiny little sends while performing less frequent recv, and intend to receive and process data from multiple server send blocks
  - Buffer bloat on server as the TCP recv buffer is not drained sufficiently
  - Delay in data receive

Standalone tests has been done, this should be merged after some integration tests on PPSSPP & PSP (and probably some issue fixing after integration tests).